### PR TITLE
Removing ":" and ";" from the list of supported characters within dev…

### DIFF
--- a/articles/iot-hub/iot-hub-devguide-identity-registry.md
+++ b/articles/iot-hub/iot-hub-devguide-identity-registry.md
@@ -143,7 +143,7 @@ Device identities are represented as JSON documents with the following propertie
 
 | Property | Options | Description |
 | --- | --- | --- |
-| deviceId |required, read-only on updates |A case-sensitive string (up to 128 characters long) of ASCII 7-bit alphanumeric characters plus certain special characters: `- : . + % _ # * ? ! ( ) , = @ ; $ '`. |
+| deviceId |required, read-only on updates |A case-sensitive string (up to 128 characters long) of ASCII 7-bit alphanumeric characters plus certain special characters: `- . + % _ # * ? ! ( ) , = @ $ '`. |
 | generationId |required, read-only |An IoT hub-generated, case-sensitive string up to 128 characters long. This value is used to distinguish devices with the same **deviceId**, when they have been deleted and re-created. |
 | etag |required, read-only |A string representing a weak ETag for the device identity, as per [RFC7232][lnk-rfc7232]. |
 | auth |optional |A composite object containing authentication information and security materials. |


### PR DESCRIPTION
…iceId

- ":" causes issues within AMQP
- ";" causes issues within connection strings